### PR TITLE
Added Cache-Control for uploading storage

### DIFF
--- a/googleapi.nimble
+++ b/googleapi.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.2"
+version       = "0.1.3"
 author        = "treeform"
 description   = "GoogleAPI - Growing collection of google APIs for nim."
 license       = "MIT"

--- a/src/googleapi/storage.nim
+++ b/src/googleapi/storage.nim
@@ -29,6 +29,12 @@ proc `$`(cache: CacheControl): string =
       "min-fresh=" & $cache.seconds
     else: $cache.kind
 
+proc `$`(cacheControls: openArray[CacheControl]): string = 
+  for i, cache in cacheControls:
+    result.add $cache
+    if i != cacheControls.high:
+      result.add ","
+
 proc initMaxAge*(s: int): CacheControl = CacheControl(kind: maxAge, seconds: s)
 proc initMaxStale*(s: int): CacheControl = CacheControl(kind: maxStale, seconds: s)
 proc initMinFresh*(s: int): CacheControl = CacheControl(kind: minfresh, seconds: s)
@@ -49,7 +55,7 @@ proc upload*(
     bucketId: string,
     objectId: string,
     data: string,
-    cacheControl = initMaxAge(3600)):
+    cacheControl: varargs[CacheControl] = initMaxAge(3600)):
     Future[JsonNode] {.async.} =
 
   let url = &"{uploadRoot}/b/{bucketId}/o?uploadType=media&name={encodeUrl(objectId)}"


### PR DESCRIPTION
Quick implementation which should allow changing the GCS cache behaviour.
As I said in the real time chat.
> i read a total of one stack oveflow and the docs for Cache-Control so i have no clue if all of the string conversions are properly handled or what actually changes with them, but using NoCache and NoStore with my unity build system does resolve my friends launcher cache requesting problems