### PR TITLE
add 5 min buffer to auth token

### DIFF
--- a/src/googleapi/connection.nim
+++ b/src/googleapi/connection.nim
@@ -53,7 +53,8 @@ proc newConnection*(clientEmail, privateKey: string): Future[Connection] {.async
   return conn
 
 proc getAuthToken*(conn: Connection): Future[string] {.async.} =
-  if conn.authTokenExpireTime > epochTime():
+  ## add a buffer of 5 minutes for how long the token is good for
+  if conn.authTokenExpireTime > epochTime() + (5 * 60):
     return conn.authToken
 
   when defined(googleApiUseQuickJwt):


### PR DESCRIPTION
- API calls sometimes produce 401 `ACCESS_TOKEN_EXPIRED` errors
- If an API call is made really close to the auth token expire time (or perhaps if there is some clock drift) the token might be expired before the call executes.
- GCP access tokens are valid for 1 hour. When refreshing, we can add a buffer of 5 minutes to ensure we don't use an expired token by mistake.